### PR TITLE
Fixed url handling if bundle contains uppercase letters

### DIFF
--- a/Pod/LMAGooglePlusSDKProvider.m
+++ b/Pod/LMAGooglePlusSDKProvider.m
@@ -76,7 +76,7 @@
     // See documentation for ClientId
     // scheme == bundleIdentifier
     NSString *bundleIdentifier = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIdentifier"];
-    if (![[url scheme] isEqualToString:bundleIdentifier]) {
+    if (![[url scheme] isEqualToString:[bundleIdentifier lowercaseString]]) {
         return NO;
     }
 


### PR DESCRIPTION
Hello.

I found issue with handling url - if my app bundle contains uppercase letters provider couldn't handle url because safari returns scheme in lowercase.

This pull request fixes it.

Thank you.
